### PR TITLE
Fix incorrect dataLayer type

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -5,7 +5,7 @@ import { redirect } from "next/navigation";
 import styles from "./not-found.module.scss";
 
 declare global {
-  var dataLayer: [any];
+  var dataLayer: any[];
 }
 
 const NotFound = () => {


### PR DESCRIPTION
## Summary
- fix TypeScript declaration for `dataLayer` in not-found page

## Testing
- `npm install` *(fails: registry unreachable)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68803a5bfd7c832ca2f29aebe958e3ee