### PR TITLE
Add dynamic sitemap

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
-//robots.txt
+# robots.txt
 
 # Block all crawlers for /accounts
 User-agent: *
@@ -7,3 +7,5 @@ Disallow: /accounts
 # Allow all crawlers
 User-agent: *
 Allow: /
+
+Sitemap: https://www.cristiandrc.dev/sitemap.xml

--- a/src/app/sitemap.xml/route.ts
+++ b/src/app/sitemap.xml/route.ts
@@ -1,0 +1,18 @@
+
+export async function GET(request: Request) {
+  const baseUrl = new URL(request.url).origin
+  const routes = ['/', '/project']
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+    routes
+      .map((route) => `  <url><loc>${baseUrl}${route}</loc></url>`) 
+      .join('\n') +
+    '\n</urlset>'
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'application/xml',
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- expose `sitemap.xml` endpoint in new app router
- reference the sitemap in `robots.txt`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68803ba5d504832cbd3d244843bcf9aa