### PR TITLE
chore: bump package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cristiandrc.dev",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cristiandrc.dev",
-      "version": "0.2.0",
+      "version": "0.3.1",
       "dependencies": {
         "@astrojs/react": "^3.6.0",
         "@astrojs/sitemap": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cristiandrc.dev",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
## Summary
- bump package version in package.json
- update package-lock.json to match

## Testing
- Not run; version-only metadata change.